### PR TITLE
initial repository setup

### DIFF
--- a/.github/workflows/llm4pddl.yml
+++ b/.github/workflows/llm4pddl.yml
@@ -1,0 +1,61 @@
+name: llm4pddl
+
+on: [push]
+
+jobs:
+  static-type-checking:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        pip install -e .
+        pip install mypy
+    - name: Mypy
+      run: |
+        mypy .
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        pip install -e .
+        pip install pytest-pylint
+    - name: Pylint
+      run: |
+        pytest . --pylint -m pylint --pylint-rcfile=.llm4pddl_pylintrc
+  autoformat:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Run YAPF to test if python code is correctly formatted
+      uses: AlexanderMelde/yapf-action@master
+      with:
+        args: --verbose --style .style.yapf
+    - name: Run isort to organize imports
+      uses: isort/isort-action@master

--- a/.github/workflows/llm4pddl.yml
+++ b/.github/workflows/llm4pddl.yml
@@ -14,7 +14,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        cache: 'pip' 
+        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install -e .
@@ -34,6 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install -e .
@@ -53,6 +55,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+        cache-dependency-path: '**/setup.py'
     - name: Run YAPF to test if python code is correctly formatted
       uses: AlexanderMelde/yapf-action@master
       with:

--- a/.github/workflows/llm4pddl.yml
+++ b/.github/workflows/llm4pddl.yml
@@ -3,6 +3,25 @@ name: llm4pddl
 on: [push]
 
 jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: '**/setup.py'
+    - run: |
+        pip install -e .
+        pip install pytest-cov
+    - name: Pytest
+      run: |
+        pytest -s tests/ --cov-config=.coveragerc --cov=llm4pddl/ --cov=tests/ --cov-fail-under=100 --cov-report=term-missing:skip-covered
   static-type-checking:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 *.csv
 *.zip
 *.so
+venv
 build
 dist
 .coverage

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[isort]
+multi_line_output = 2
+skip = venv

--- a/.llm4pddl_pylintrc
+++ b/.llm4pddl_pylintrc
@@ -288,7 +288,7 @@ ignore-on-opaque-inference=yes
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime

--- a/.llm4pddl_pylintrc
+++ b/.llm4pddl_pylintrc
@@ -1,0 +1,427 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=numpy,pybullet,torch,tensorflow
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add paths to the blacklist.
+ignore-paths=third_party
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,not-callable,logging-format-interpolation,consider-using-enumerate,invalid-name,eval-used,len-as-condition,raise-missing-from,consider-using-with,logging-fstring-interpolation,cache-max-size-none,unnecessary-lambda-assignment
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=10
+
+
+[BASIC]
+
+# Naming hint for argument names
+argument-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct argument names
+argument-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Naming hint for attribute names
+attr-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct attribute names
+attr-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,99}|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,99}|(__.*__))$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,l,t,m,n,ex,Run,_,i1,i2,i3,j1,j2,j3,v,pt,ax,X,Y,Z,W,W1,W2,W3,x,y,z,w,Xtest,Ytest,Xtrain,Ytrain,Yhat,p,dt,f,g,h,xs,ys,e,ie,kb,op,T,R,S,A,O,c,vs,c1,c2,s,a,r,cp,vf,M,N
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming hint for variable names
+variable-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=10000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=100
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,tensorflow.python.util.tf_contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=torch.*
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=yes
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=1000
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=1000
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=1000
+
+# Maximum number of branch for function / method body
+max-branches=1000
+
+# Maximum number of locals for function / method body
+max-locals=1000
+
+# Maximum number of parents for a class (see R0901).
+max-parents=1000
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=1000
+
+# Maximum number of return / yield for function / method body
+max-returns=1000
+
+# Maximum number of statements in function / method body
+max-statements=1000
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = pep8
+split_before_logical_operator = true
+column_limit = 79
+spaces_before_comment = 2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # llm4pddl
+
+Under development.
+
+## Requirements
+* Python 3.8+
+
+## Instructions For Contributing
+* (Highly recommended) Make a virtual environment:
+    * `virtualenv venv`
+    * `source venv/bin/activate`
+* Run `pip install -e .[develop]` to install all dependencies for development.
+* You can't push directly to master. Make a new branch in this repository (don't use a fork, since that will not properly trigger the checks when you make a PR). When your code is ready for review, make a PR and request reviews from the appropriate people.
+* To merge a PR, you need at least one approval, and you have to pass the 4 checks defined in `.github/workflows/llm4pddl.yml`, which you can run locally as follows:
+    * `pytest -s tests/ --cov-config=.coveragerc --cov=llm4pddl/ --cov=tests/ --cov-fail-under=100 --cov-report=term-missing:skip-covered --durations=0`
+    * `mypy .`
+    * `pytest . --pylint -m pylint --pylint-rcfile=.llm4pddl_pylintrc`
+    * `./run_autoformat.sh`
+* The first one is the unit testing check, which verifies that unit tests pass and that code is adequately covered. The "100" means that all lines in every file must be covered.
+* The second one is the static typing check, which uses Mypy to verify type annotations.
+* The third one is the linter check, which runs Pylint with the custom config file `.llm4pddl_pylintrc` in the root of this repository. Feel free to edit this file as necessary.
+* The fourth one is the autoformatting check, which uses the custom config files `.style.yapf` and `.isort.cfg` in the root of this repository.

--- a/llm4pddl/flags.py
+++ b/llm4pddl/flags.py
@@ -1,4 +1,4 @@
-"""Command-line flags."""
+"""Command line flags."""
 
 from absl import flags
 

--- a/llm4pddl/flags.py
+++ b/llm4pddl/flags.py
@@ -1,0 +1,11 @@
+"""Command-line flags."""
+
+from absl import flags
+
+FLAGS = flags.FLAGS
+
+# Required flags.
+flags.DEFINE_string("domain", None, "The name of a PDDL domain.")
+flags.mark_flag_as_required("domain")
+flags.DEFINE_string("approach", None, "The name of an approach.")
+flags.mark_flag_as_required("approach")

--- a/llm4pddl/flags.py
+++ b/llm4pddl/flags.py
@@ -1,11 +1,14 @@
 """Command line flags."""
 
-from absl import flags
+import argparse
 
-FLAGS = flags.FLAGS
+FLAGS = argparse.Namespace()  # set by parse_flags() below
 
-# Required flags.
-flags.DEFINE_string("domain", None, "The name of a PDDL domain.")
-flags.mark_flag_as_required("domain")
-flags.DEFINE_string("approach", None, "The name of an approach.")
-flags.mark_flag_as_required("approach")
+
+def parse_flags() -> None:
+    """Parse the command line flags and update global FLAGS."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--domain", required=True, type=str)
+    parser.add_argument("--approach", required=True, type=str)
+    args = parser.parse_args()
+    FLAGS.__dict__.update(args.__dict__)

--- a/llm4pddl/main.py
+++ b/llm4pddl/main.py
@@ -1,14 +1,19 @@
 """Main script for running experiments."""
 
-from absl import app
 from typing import Sequence
+
+from absl import app
 
 from llm4pddl.flags import FLAGS
 
 
 def _main(argv: Sequence[str]) -> None:
     assert len(argv) == 1  # just the name of this file
-    
+    domain = FLAGS.domain
+    approach = FLAGS.approach
+    print("Domain:", domain)
+    print("Approach:", approach)
+
 
 if __name__ == "__main__":
     app.run(_main)

--- a/llm4pddl/main.py
+++ b/llm4pddl/main.py
@@ -1,0 +1,14 @@
+"""Main script for running experiments."""
+
+from absl import app
+from typing import Sequence
+
+from llm4pddl.flags import FLAGS
+
+
+def _main(argv: Sequence[str]) -> None:
+    assert len(argv) == 1  # just the name of this file
+    
+
+if __name__ == "__main__":
+    app.run(_main)

--- a/llm4pddl/main.py
+++ b/llm4pddl/main.py
@@ -1,19 +1,16 @@
 """Main script for running experiments."""
 
-from typing import Sequence
-
-from absl import app
-
-from llm4pddl.flags import FLAGS
+from llm4pddl.flags import FLAGS, parse_flags
 
 
-def _main(argv: Sequence[str]) -> None:
-    assert len(argv) == 1  # just the name of this file
+def _main() -> None:
+    """The main entry point."""
+    parse_flags()
     domain = FLAGS.domain
     approach = FLAGS.approach
     print("Domain:", domain)
     print("Approach:", approach)
 
 
-if __name__ == "__main__":
-    app.run(_main)
+if __name__ == "__main__":  # pragma: no cover
+    _main()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+strict_equality = True
+disallow_untyped_calls = True
+warn_unreachable = True
+exclude = (build|venv|tests|scripts)
+
+[mypy-absl.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True

--- a/run_autoformat.sh
+++ b/run_autoformat.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+yapf -i -r --style .style.yapf . --exclude venv
+docformatter -i -r . --exclude venv
+isort .

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,19 @@
-from setuptools import setup, find_packages
+"""Usage examples:
 
-setup(
-    name="llm4pddl",
-    version="0.1.0",
-    packages=find_packages(include=["llm4pddl", "llm4pddl.*"]),
-    install_requires=[
-        "absl-py",
-        "PyYAML",
-    ],
-    extras_require={"develop": [
-        "mypy",
-        "pytest-cov>=2.12.1",
-        "pytest-pylint>=0.18.0",
-        "yapf==0.32.0",
-        "docformatter",
-        "isort"
-    ]}
-)
+pip install -e . pip install -e .[develop]
+"""
+from setuptools import find_packages, setup
 
+setup(name="llm4pddl",
+      version="0.1.0",
+      packages=find_packages(include=["llm4pddl", "llm4pddl.*"]),
+      install_requires=[
+          "absl-py",
+          "PyYAML",
+      ],
+      extras_require={
+          "develop": [
+              "mypy", "pytest-cov>=2.12.1", "pytest-pylint>=0.18.0",
+              "yapf==0.32.0", "docformatter", "isort"
+          ]
+      })

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
-"""Usage examples:
+"""Setup script.
 
-pip install -e . pip install -e .[develop]
+Usage examples:
+
+    pip install -e .
+    pip install -e .[develop]
 """
 from setuptools import find_packages, setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,20 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='llm4pddl',
-    version='0.1.0',
-    packages=find_packages(include=['llm4pddl', 'llm4pddl.*']),
+    name="llm4pddl",
+    version="0.1.0",
+    packages=find_packages(include=["llm4pddl", "llm4pddl.*"]),
     install_requires=[
-        'absl-py',
-        'PyYAML',
+        "absl-py",
+        "PyYAML",
     ],
+    extras_require={"develop": [
+        "mypy",
+        "pytest-cov>=2.12.1",
+        "pytest-pylint>=0.18.0",
+        "yapf==0.32.0",
+        "docformatter",
+        "isort"
+    ]}
 )
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='llm4pddl',
+    version='0.1.0',
+    packages=find_packages(include=['llm4pddl', 'llm4pddl.*']),
+    install_requires=[
+        'absl-py',
+        'PyYAML',
+    ],
+)
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name="llm4pddl",
       version="0.1.0",
       packages=find_packages(include=["llm4pddl", "llm4pddl.*"]),
       install_requires=[
-          "absl-py",
           "PyYAML",
       ],
       extras_require={

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,11 @@
+"""Tests for main.py."""
+
+import sys
+
+from llm4pddl.main import _main
+
+
+def test_main():
+    """Tests for main.py."""
+    sys.argv = ["dummy", "--domain", "my_domain", "--approach", "my_approach"]
+    _main()  # should run


### PR DESCRIPTION
just getting the barebones stuff in place. versus the predicators setup, there are two main differences:
1. use `setup.py` instead of forcing people to update their pythonpath.
2. use one `FLAGS` instead of separating CFG and args (see flags.py)

another minor thing is that the autoformatting commands are now in a script instead of just running one line.

see the README for the basic installation instructions. afterwards, this should just print out the flags: `python llm4pddl/main.py --domain foo --approach bar`