### PR TITLE
require python hash seed 0

### DIFF
--- a/.github/workflows/llm4pddl.yml
+++ b/.github/workflows/llm4pddl.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Pytest
       run: |
         pytest -s tests/ --cov-config=.coveragerc --cov=llm4pddl/ --cov=tests/ --cov-fail-under=100 --cov-report=term-missing:skip-covered
+      env:
+          PYTHONHASHSEED: 0
   static-type-checking:
     runs-on: ubuntu-latest
     strategy:
@@ -68,6 +70,8 @@ jobs:
     - name: Pylint
       run: |
         pytest . --pylint -m pylint --pylint-rcfile=.llm4pddl_pylintrc
+      env:
+        PYTHONHASHSEED: 0
   autoformat:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Under development.
 
 ### `PYTHONHASHSEED`
 Our code assumes that python hashing is deterministic between processes, which is [not true by default](https://stackoverflow.com/questions/30585108/disable-hash-randomization-from-within-python-program).
-Please make sure to `export PYTHONHASHSEED=0` when running the code. You can add this line to your bash profile, or prepend `export PYTHONHASHSEED=0` to any command line call, e.g., `export PYTHONHASHSEED=0 python llm4pddl/main.py --env ...`.
+Please make sure to `export PYTHONHASHSEED=0` when running the code. You can add this line to your bash/zsh profile, or prepend `export PYTHONHASHSEED=0` to any command line call, e.g., `export PYTHONHASHSEED=0 python llm4pddl/main.py --env ...`.
 
 ## Requirements
 * Python 3.8+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Under development.
 
+### `PYTHONHASHSEED`
+Our code assumes that python hashing is deterministic between processes, which is [not true by default](https://stackoverflow.com/questions/30585108/disable-hash-randomization-from-within-python-program).
+Please make sure to `export PYTHONHASHSEED=0` when running the code. You can add this line to your bash profile, or prepend `export PYTHONHASHSEED=0` to any command line call, e.g., `export PYTHONHASHSEED=0 python llm4pddl/main.py --env ...`.
+
 ## Requirements
 * Python 3.8+
 * Tested on MacOS Catalina and Ubuntu 18.04

--- a/llm4pddl/main.py
+++ b/llm4pddl/main.py
@@ -18,6 +18,9 @@ from llm4pddl.envs.base_env import BaseEnv
 from llm4pddl.flags import FLAGS, parse_flags
 from llm4pddl.structs import Metrics, TaskMetrics
 
+assert os.environ.get("PYTHONHASHSEED") == "0", \
+        "Please add `export PYTHONHASHSEED=0` to your bash profile!"
+
 
 def _main() -> None:
     """The main entry point."""

--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -107,6 +107,7 @@ def get_cmds_to_prep_repo(branch: str) -> List[str]:
     """Get the commands that should be run while already in the repository but
     before launching the experiments."""
     return [
+        "export PYTHONHASHSEED=0",
         "mkdir -p logs",
         "git stash",
         "git fetch --all",


### PR DESCRIPTION
I realized that we need to enforce that hashing is deterministic because we're using hashing in constructing the filenames for LLM caching. see README for steps that will need to be taken after this PR is merged.