### PR TITLE
revert randomization in pyperplan tiebreaking

### DIFF
--- a/llm4pddl/approaches/pure_planning_approach.py
+++ b/llm4pddl/approaches/pure_planning_approach.py
@@ -23,4 +23,4 @@ class PurePlanningApproach(BaseApproach):
         return "pure-planning"
 
     def solve(self, task: Task) -> Tuple[Optional[Plan], TaskMetrics]:
-        return utils.run_planning(task, self._rng, planner=FLAGS.planner)
+        return utils.run_planning(task, planner=FLAGS.planner)

--- a/llm4pddl/dataset.py
+++ b/llm4pddl/dataset.py
@@ -2,8 +2,6 @@
 
 from typing import Sequence
 
-import numpy as np
-
 from llm4pddl import utils
 from llm4pddl.flags import FLAGS
 from llm4pddl.structs import Dataset, Datum, Task
@@ -12,11 +10,8 @@ from llm4pddl.structs import Dataset, Datum, Task
 def create_dataset(train_tasks: Sequence[Task]) -> Dataset:
     """Run planning on the train tasks to create training data."""
     dataset: Dataset = []
-    rng = np.random.default_rng(FLAGS.seed)
     for task in train_tasks:
-        solution, _ = utils.run_planning(task,
-                                         rng,
-                                         planner=FLAGS.data_gen_planner)
+        solution, _ = utils.run_planning(task, planner=FLAGS.data_gen_planner)
         assert solution is not None
         datum = Datum(task, solution)
         dataset.append(datum)

--- a/llm4pddl/utils.py
+++ b/llm4pddl/utils.py
@@ -45,11 +45,10 @@ def validate_plan(task: Task, plan: Plan) -> bool:
 
 def run_planning(
         task: Task,
-        rng: np.random.Generator,
         planner: str = "pyperplan") -> Tuple[Optional[Plan], TaskMetrics]:
     """Find a plan."""
     if planner == "pyperplan":
-        return run_pyperplan_planning(task, rng)
+        return run_pyperplan_planning(task)
     if planner == "fastdownward":  # pragma: no cover
         return run_fastdownward_planning(task)
     if planner == "fastdownward-hff-gbfs":  # pragma: no cover
@@ -61,7 +60,6 @@ def run_planning(
 
 def run_pyperplan_planning(
         task: Task,
-        rng: np.random.Generator,
         heuristic: str = "hff",
         search: str = "gbf") -> Tuple[Optional[Plan], TaskMetrics]:
     """Find a plan with pyperplan."""
@@ -74,7 +72,6 @@ def run_pyperplan_planning(
         task.problem_file,
         search_fn,
         heuristic_fn,
-        rng=rng,
         timeout=FLAGS.planning_timeout,
     )
     logging.disable(logging.NOTSET)

--- a/scripts/configs/main.yaml
+++ b/scripts/configs/main.yaml
@@ -1,20 +1,20 @@
 # Our main experiments configuration file.
 ---
 APPROACHES:
-  pyperplan-only:
-    NAME: "pure-planning"
-    FLAGS:
-      planner: pyperplan
-  fd-only:
-    NAME: "pure-planning"
-    FLAGS:
-      planner: fastdownward
+  # pyperplan-only:
+  #   NAME: "pure-planning"
+  #   FLAGS:
+  #     planner: pyperplan
+  # fd-only:
+  #   NAME: "pure-planning"
+  #   FLAGS:
+  #     planner: fastdownward
   llm-standard:
     NAME: "llm-standard"
     FLAGS: {}
-  llm-multi:
-    NAME: "llm-multi"
-    FLAGS: {}
+  # llm-multi:
+  #   NAME: "llm-multi"
+  #   FLAGS: {}
 ENVS:
   airport:
     NAME: "pyperplan-airport"
@@ -85,4 +85,4 @@ FLAGS:
   num_train_tasks: 5
   num_eval_tasks: 10
 START_SEED: 456
-NUM_SEEDS: 5
+NUM_SEEDS: 1

--- a/tests/approaches/test_llm_approaches.py
+++ b/tests/approaches/test_llm_approaches.py
@@ -2,7 +2,6 @@
 
 import shutil
 
-import numpy as np
 import pytest
 
 from llm4pddl import utils
@@ -67,8 +66,7 @@ def test_llm_standard_approach(env_name):
     # Test successful usage, where the LLM output corresponds to a plan.
     task_idx = 0
     task = train_tasks[task_idx]
-    rng = np.random.default_rng(123)
-    plan, _ = utils.run_planning(task, rng)
+    plan, _ = utils.run_planning(task)
     ideal_response = "\n".join(plan)
     # Add an empty line to the ideal response, should be no problem.
     ideal_response = "\n" + ideal_response
@@ -103,8 +101,7 @@ def test_llm_standard_approach_failure_cases():
     approach._llm = llm  # pylint: disable=protected-access
     task_idx = 0
     task = train_tasks[task_idx]
-    rng = np.random.default_rng(123)
-    ideal_plan, _ = utils.run_planning(task, rng)
+    ideal_plan, _ = utils.run_planning(task)
     ideal_response = "\n".join(ideal_plan)
 
     # Test general approach failure.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@
 import os
 import tempfile
 
-import numpy as np
 import pytest
 
 from llm4pddl import utils
@@ -307,24 +306,23 @@ def test_run_planning(domain_file, problem_file, impossible_problem_file):
     """
     utils.reset_flags({"planning_timeout": 100})
     # Test planning successfully.
-    rng = np.random.default_rng(123)
     task = Task(domain_file, problem_file)
-    plan, metrics = utils.run_planning(task, rng)
+    plan, metrics = utils.run_planning(task)
     assert metrics["nodes_created"] > metrics["nodes_expanded"]
     assert plan is not None
     assert utils.validate_plan(task, plan)
     # Test planning in an impossible problem.
     impossible_task = Task(domain_file, impossible_problem_file)
-    plan, metrics = utils.run_planning(impossible_task, rng)
+    plan, metrics = utils.run_planning(impossible_task)
     assert metrics["nodes_created"] == metrics["nodes_expanded"] == 1
     assert plan is None
     # Test planning in a pyperplan benchmark problem.
     task = utils.get_pyperplan_benchmark_task("blocks", 1)
-    plan, metrics = utils.run_planning(task, rng)
+    plan, metrics = utils.run_planning(task)
     assert metrics["nodes_created"] > metrics["nodes_expanded"]
     assert plan is not None
     assert utils.validate_plan(task, plan)
     # Test planning with an invalid planner.
     with pytest.raises(NotImplementedError) as e:
-        utils.run_planning(task, rng, planner="not a real planner")
+        utils.run_planning(task, planner="not a real planner")
     assert "Unrecognized planner" in str(e)


### PR DESCRIPTION
I went back and forth about this a lot, but now feel that we should stick with the original implementation, which does not randomly tiebreak during search.

Pros:
- Fewer changes to the off-the-shelf code
- Planning is now deterministic, so we don't have to run it more than once
- Fast downward and pyperplan now match

Cons:
- Since planning is deterministic, we won't get statistical results (e.g. standard deviation)
- It seemed like randomized tiebreaking was helping sometimes