### PR TITLE
fix case where llm outputs a special kind of invalid action

### DIFF
--- a/llm4pddl/approaches/llm_planning_approach.py
+++ b/llm4pddl/approaches/llm_planning_approach.py
@@ -22,10 +22,21 @@ class LLMPlanningApproach(LLMOpenLoopApproach):
             task: Task) -> Tuple[Optional[Plan], TaskMetrics]:
         # Turn each response into a sequence of actions. Do not check the
         # preconditions of the actions; rely on the planner to do that.
-        partial_plans = [
-            self._llm_response_to_plan(r, task) for r in responses
-        ]
-        operator_seqs = [[utils.parse_plan_step(a, task) for a in p]
-                         for p in partial_plans]
+        partial_plans = []
+        for response in responses:
+            action_str_plan = self._llm_response_to_plan(response, task)
+            partial_plan = []
+            for action_str in action_str_plan:
+                action = utils.parse_plan_step(action_str, task)
+                # Break early if an invalid action is encountered.
+                # This is a tricky and rare case to cover, because most
+                # invalid actions are pruned by _llm_response_to_plan(),
+                # but if the action is invalid because it is irrelevant
+                # to the task, then this will only be caught during
+                # grounding.
+                if action is None:  # pragma: no cover
+                    break
+                partial_plan.append(action)
+            partial_plans.append(partial_plan)
         # Use the partial plans to guide the planner.
-        return utils.run_pyperplan_planning(task, partial_plans=operator_seqs)
+        return utils.run_pyperplan_planning(task, partial_plans=partial_plans)

--- a/llm4pddl/utils.py
+++ b/llm4pddl/utils.py
@@ -234,14 +234,21 @@ def get_all_ground_operators(task: Task) -> Dict[str, PyperplanAction]:
 
 
 @functools.lru_cache(maxsize=None)
-def parse_plan_step(action_str: str, task: Task) -> PyperplanAction:
-    """Parse a string action into a Pyperplan action (ground operator)."""
+def parse_plan_step(action_str: str, task: Task) -> Optional[PyperplanAction]:
+    """Parse a string action into a Pyperplan action (ground operator).
+
+    If the ground operator is invalid, returns None. This can be the
+    case when the ground operator has a static precondition that is not
+    in the initial state of the task, or if the operator is deemed
+    irrelevant for the task based on the relevance analysis in pyperplan
+    grounding.
+    """
     # Match the action to a ground operator in the set of all ground operators
     # from pyperplan. Note that the grounding is cached for efficiency. We
     # do it this way, rather than reconstructing the operators, because
     # pyperplan grounding removes static preconditions.
     ground_ops = get_all_ground_operators(task)
-    return ground_ops[action_str]
+    return ground_ops.get(action_str, None)
 
 
 def pred_to_str(pred: PyperplanPredicate) -> str:


### PR DESCRIPTION
before this, the following would crash with a key error:

`python llm4pddl/main.py --env pyperplan-logistics --approach llm-standard-plan --seed 456`

now it gets 10/10.