### PR TITLE
catch another rare kind of openai exception

### DIFF
--- a/llm4pddl/llm_interface.py
+++ b/llm4pddl/llm_interface.py
@@ -135,7 +135,8 @@ class OpenAILLM(LargeLanguageModel):
                 # Successfully queried, so break.
                 break
             except (openai.error.RateLimitError,
-                    openai.error.APIConnectionError):
+                    openai.error.APIConnectionError,
+                    openai.error.APIError):
                 # Wait for 60 seconds if this limit is reached. Hopefully rare.
                 time.sleep(60)
         else:

--- a/llm4pddl/llm_interface.py
+++ b/llm4pddl/llm_interface.py
@@ -135,8 +135,7 @@ class OpenAILLM(LargeLanguageModel):
                 # Successfully queried, so break.
                 break
             except (openai.error.RateLimitError,
-                    openai.error.APIConnectionError,
-                    openai.error.APIError):
+                    openai.error.APIConnectionError, openai.error.APIError):
                 # Wait for 60 seconds if this limit is reached. Hopefully rare.
                 time.sleep(60)
         else:


### PR DESCRIPTION
example:

```
Traceback (most recent call last):
  File "llm4pddl/main.py", line 111, in <module>
    _main()
  File "llm4pddl/main.py", line 41, in _main
    _run_pipeline(approach, env)
  File "llm4pddl/main.py", line 55, in _run_pipeline
    results = _run_evaluation(approach, eval_tasks, env.get_name())
  File "llm4pddl/main.py", line 80, in _run_evaluation
    plan, solve_metrics = approach.solve(task)
  File "/home/ubuntu/llm4pddl/llm4pddl/approaches/llm_open_loop_approach.py", line 41, in solve
    responses = self._llm.sample_completions(
  File "/home/ubuntu/llm4pddl/llm4pddl/llm_interface.py", line 78, in sample_completions
    completions = self._sample_completions(prompt, temperature, seed,
  File "/home/ubuntu/llm4pddl/llm4pddl/llm_interface.py", line 127, in _sample_completions
    response = openai.Completion.create(  # type: ignore
  File "/home/ubuntu/.local/lib/python3.8/site-packages/openai/api_resources/completion.py", line 25, in create
    return super().create(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 115, in create
    response, _, api_key = requestor.request(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/openai/api_requestor.py", line 121, in request
    resp, got_stream = self._interpret_response(result, stream)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/openai/api_requestor.py", line 328, in _interpret_response
    self._interpret_response_line(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/openai/api_requestor.py", line 361, in _interpret_response_line
    raise self.handle_error_response(
openai.error.APIError: Internal server error
```