### PR TITLE
unit test speedups

### DIFF
--- a/llm4pddl/envs/__init__.py
+++ b/llm4pddl/envs/__init__.py
@@ -6,46 +6,6 @@ from llm4pddl.envs.custom_env import CustomEnv
 from llm4pddl.envs.manual_train_env import ManualTrainEnv
 from llm4pddl.envs.pyperplan_env import PyperplanEnv
 
-PYPERPLAN_BENCHMARKS = [
-    "airport",
-    "blocks",
-    "depot",
-    "elevators",
-    "freecell",
-    "gripper",
-    "logistics",
-    "miconic",
-    "movie",
-    "openstacks",
-    "parcprinter",
-    "pegsol",
-    "psr-small",
-    "rovers",
-    "satellite",
-    "scanalyzer",
-    "sokoban",
-    "tpp",
-    "transport",
-    "woodworking",
-    "zenotravel",
-]
-
-CUSTOM_BENCHMARKS = [
-    "dressed", "easy_blocks", "medium_blocks", "easy_delivery",
-    "medium_delivery", "easy_spanner", "medium_spanner"
-]
-
-AUGMENTED_BENCHMARKS = [f"pyperplan-{b}" for b in PYPERPLAN_BENCHMARKS]
-
-MANUAL_TRAIN_BENCHMARKS = [
-    "pyperplan-gripper", "pyperplan-tpp", "pyperplan-miconic"
-]
-
-ALL_ENVS = [f"pyperplan-{b}" for b in PYPERPLAN_BENCHMARKS] + [
-    f"custom-{b}" for b in CUSTOM_BENCHMARKS
-] + [f"augmented-{b}" for b in AUGMENTED_BENCHMARKS
-     ] + [f"manual-{b}" for b in MANUAL_TRAIN_BENCHMARKS]
-
 
 def create_env(env_name: str) -> BaseEnv:
     """Create an environment."""

--- a/llm4pddl/envs/assets/pddl/augmented/generate_augmented_tasks.py
+++ b/llm4pddl/envs/assets/pddl/augmented/generate_augmented_tasks.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Iterator, List, Sequence
 
 from llm4pddl import utils
-from llm4pddl.envs import PYPERPLAN_BENCHMARKS
 from llm4pddl.flags import FLAGS
 from llm4pddl.structs import PyperplanProblem, Task
 
@@ -225,7 +224,10 @@ def _generate_tasks_for_env(original_task_dir: Path, out_dir: Path,
 
 
 def _main(num_original_train_tasks: int, max_num_iters: int) -> None:
-    for benchmark_name in PYPERPLAN_BENCHMARKS:
+    benchmarks = sorted(f.name
+                        for f in os.scandir(utils.PYPERPLAN_BENCHMARK_DIR)
+                        if f.is_dir())
+    for benchmark_name in benchmarks:
         print(f"******** Starting augmentation for {benchmark_name} *********")
         original_task_dir = utils.PYPERPLAN_BENCHMARK_DIR / benchmark_name
         out_dir = utils.AUGMENTED_BENCHMARK_DIR / f"pyperplan-{benchmark_name}"

--- a/tests/approaches/test_llm_open_loop_approach.py
+++ b/tests/approaches/test_llm_open_loop_approach.py
@@ -11,7 +11,7 @@ from llm4pddl import utils
 from llm4pddl.approaches import create_approach
 from llm4pddl.approaches.llm_open_loop_approach import LLMOpenLoopApproach
 from llm4pddl.dataset import create_dataset
-from llm4pddl.envs import ALL_ENVS, create_env
+from llm4pddl.envs import create_env
 from llm4pddl.llm_interface import LargeLanguageModel
 from llm4pddl.structs import Datum, LLMResponse
 
@@ -39,7 +39,9 @@ class _MockLLM(LargeLanguageModel):
         return [response]
 
 
-@pytest.mark.parametrize('env_name', ALL_ENVS)
+@pytest.mark.parametrize(
+    'env_name',
+    ["pyperplan-blocks", "custom-easy_spanner", "pyperplan-woodworking"])
 def test_llm_standard_approach(env_name):
     """Tests for the LLM standard approach."""
     cache_dir = "_fake_llm_cache_dir"

--- a/tests/envs/test_augmented_env.py
+++ b/tests/envs/test_augmented_env.py
@@ -1,7 +1,6 @@
 """Tests for AugmentedEnv()."""
 
 from llm4pddl import utils
-from llm4pddl.envs import AUGMENTED_BENCHMARKS
 from llm4pddl.envs.augmented_env import AugmentedEnv
 
 
@@ -12,10 +11,10 @@ def test_augmented_env():
         "num_eval_tasks": 10,
         "train_task_offset": 0
     })
-    for env_name in AUGMENTED_BENCHMARKS:
-        env = AugmentedEnv(env_name)
-        assert env.get_name() == f'augmented-{env_name}'
-        training_tasks = env.get_train_tasks()
-        assert len(training_tasks) == 5
-        eval_tasks = env.get_eval_tasks()
-        assert len(eval_tasks) == 10
+    env_name = "pyperplan-blocks"
+    env = AugmentedEnv(env_name)
+    assert env.get_name() == f'augmented-{env_name}'
+    training_tasks = env.get_train_tasks()
+    assert len(training_tasks) == 5
+    eval_tasks = env.get_eval_tasks()
+    assert len(eval_tasks) == 10

--- a/tests/envs/test_custom_env.py
+++ b/tests/envs/test_custom_env.py
@@ -1,7 +1,6 @@
 """Tests custom_env.py."""
 
 from llm4pddl import utils
-from llm4pddl.envs import CUSTOM_BENCHMARKS
 from llm4pddl.envs.custom_env import CustomEnv
 
 
@@ -12,10 +11,10 @@ def test_custom_env():
         "num_eval_tasks": 10,
         "train_task_offset": 0
     })
-    for env_name in CUSTOM_BENCHMARKS:
-        env = CustomEnv(env_name)
-        assert env.get_name() == f'custom-{env_name}'
-        training_tasks = env.get_train_tasks()
-        assert len(training_tasks) == 5
-        eval_tasks = env.get_eval_tasks()
-        assert len(eval_tasks) == 10
+    env_name = "dressed"
+    env = CustomEnv(env_name)
+    assert env.get_name() == f'custom-{env_name}'
+    training_tasks = env.get_train_tasks()
+    assert len(training_tasks) == 5
+    eval_tasks = env.get_eval_tasks()
+    assert len(eval_tasks) == 10

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -3,10 +3,13 @@
 import pytest
 
 from llm4pddl import utils
-from llm4pddl.envs import ALL_ENVS, create_env
+from llm4pddl.envs import create_env
 
 
-@pytest.mark.parametrize("env_name", ALL_ENVS)
+@pytest.mark.parametrize("env_name", [
+    "pyperplan-blocks", "custom-dressed", "augmented-pyperplan-blocks",
+    "manual-pyperplan-gripper"
+])
 def test_create_env(env_name):
     """Tests for create_env()."""
     utils.reset_flags({

--- a/tests/envs/test_manual_train_env.py
+++ b/tests/envs/test_manual_train_env.py
@@ -1,7 +1,6 @@
 """Tests for ManualTrainEnv()."""
 
 from llm4pddl import utils
-from llm4pddl.envs import MANUAL_TRAIN_BENCHMARKS
 from llm4pddl.envs.manual_train_env import ManualTrainEnv
 
 
@@ -12,10 +11,10 @@ def test_manual_train_env():
         "num_eval_tasks": 10,
         "train_task_offset": 0
     })
-    for env_name in MANUAL_TRAIN_BENCHMARKS:
-        env = ManualTrainEnv(env_name)
-        assert env.get_name() == f'manual-{env_name}'
-        training_tasks = env.get_train_tasks()
-        assert len(training_tasks) == 1
-        eval_tasks = env.get_eval_tasks()
-        assert len(eval_tasks) == 10
+    env_name = "pyperplan-gripper"
+    env = ManualTrainEnv(env_name)
+    assert env.get_name() == f'manual-{env_name}'
+    training_tasks = env.get_train_tasks()
+    assert len(training_tasks) == 1
+    eval_tasks = env.get_eval_tasks()
+    assert len(eval_tasks) == 10

--- a/tests/envs/test_pyperplan_env.py
+++ b/tests/envs/test_pyperplan_env.py
@@ -1,7 +1,6 @@
 """Tests for PyperplanEnv()."""
 
 from llm4pddl import utils
-from llm4pddl.envs import PYPERPLAN_BENCHMARKS
 from llm4pddl.envs.pyperplan_env import PyperplanEnv
 
 
@@ -12,10 +11,10 @@ def test_pyperplan_env():
         "num_eval_tasks": 10,
         "train_task_offset": 0
     })
-    for benchmark_name in PYPERPLAN_BENCHMARKS:
-        env = PyperplanEnv(benchmark_name)
-        assert env.get_name() == f"pyperplan-{benchmark_name}"
-        train_tasks = env.get_train_tasks()
-        assert len(train_tasks) == 5
-        eval_tasks = env.get_eval_tasks()
-        assert len(eval_tasks) == 10
+    benchmark_name = "blocks"
+    env = PyperplanEnv(benchmark_name)
+    assert env.get_name() == f"pyperplan-{benchmark_name}"
+    train_tasks = env.get_train_tasks()
+    assert len(train_tasks) == 5
+    eval_tasks = env.get_eval_tasks()
+    assert len(eval_tasks) == 10


### PR DESCRIPTION
closes #137 

results of `pytest -s tests/ --cov-config=.coveragerc --cov=llm4pddl/ --cov=tests/ --cov-fail-under=100 --cov-report=term-missing:skip-covered --durations=0` now:

```
==================================================================================== slowest durations =====================================================================================
6.08s call     tests/approaches/test_approaches.py::test_create_approach
3.52s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach_dynamic_big_example
3.11s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach_dynamic_small_example
2.12s call     tests/approaches/test_llm_open_loop_approach.py::test_get_closest_datums
1.94s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach[pyperplan-woodworking]
1.89s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach_failure_cases[standard]
1.82s call     tests/approaches/test_llm_open_loop_approach.py::test_get_cosine_sim
1.76s call     tests/approaches/test_llm_open_loop_approach.py::test_embed_task
1.69s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach[custom-easy_spanner]
1.69s call     tests/approaches/test_llm_planning_approach.py::test_llm_planning_planning_approach
1.67s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach_failure_cases[group-by-predicate]
1.59s call     tests/approaches/test_llm_open_loop_approach.py::test_embed_tasks
1.58s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_multi_approach
1.54s call     tests/approaches/test_llm_open_loop_approach.py::test_make_embeddings_mapping
1.48s call     tests/approaches/test_llm_open_loop_approach.py::test_llm_standard_approach[pyperplan-blocks]
1.34s call     tests/test_llm_interface.py::test_openai_llm
0.12s call     tests/test_dataset.py::test_manual_data_generation[pyperplan-gripper]
0.09s call     tests/envs/test_augmented_env.py::test_augmented_env
0.09s call     tests/test_dataset.py::test_manual_data_generation[pyperplan-blocks]
0.07s call     tests/envs/test_custom_env.py::test_custom_env
0.05s call     tests/test_main.py::test_run_pipeline
0.05s call     tests/test_main.py::test_main
0.05s call     tests/test_utils.py::test_validate_plan
0.04s call     tests/approaches/test_pure_planning_approach.py::test_pure_planning_approach
0.04s call     tests/envs/test_envs.py::test_create_env[manual-pyperplan-gripper]
0.03s call     tests/test_utils.py::test_run_planning
0.02s call     tests/test_utils.py::test_pyperplan_problem_to_str
0.01s call     tests/test_main.py::test_run_evaluation

(104 durations < 0.005s hidden.  Use -vv to show these durations.)
=================================================================================== 44 passed in 36.58s ====================================================================================
```