### PR TITLE
create success-only metrics

### DIFF
--- a/scripts/get_visualization.py
+++ b/scripts/get_visualization.py
@@ -4,7 +4,7 @@ import argparse
 from typing import Dict
 
 import matplotlib.pyplot as plt
-from analyze_results import _load_results
+from analyze_results import _create_derived_cols, _load_results
 
 APPROACHES = [
     "llm-standard-plan", "llm-multi", "llm-multi-plan", "fd-only",
@@ -26,7 +26,8 @@ def _construct_dictionaries(input_dir: str) -> Dict[str, Dict[str, str]]:
     for name in APPROACHES:
         approaches[name] = {}
 
-    df = _load_results(input_dir)
+    derived_cols = _create_derived_cols(input_dir)
+    df = _load_results(input_dir, derived_cols)
     column_labels = list(df.columns)
     env_column_index = column_labels.index('env')
     approach_column_index = column_labels.index('approach_id')


### PR DESCRIPTION
closes #130 

reports metrics that are averaged over only tasks where ALL approaches succeeded (across all seeds).

example:
```
python scripts/analyze_results.py --results_dir ~/Dropbox/llm4pddl/results/fmdm/results/all_planning
```
```
SUMMARY OF THE SUMMARY:
                                  solve_time  nodes_created  nodes_expanded   success  success_nodes_created  success_nodes_expanded
approach_id                                                                                                                         
fd-only                             5.484079   47791.033333    40299.100000  0.988889             399.794444              338.305556
llm-standard-no-autoregress-plan   41.663344    4424.288889     2473.640000  0.914444            1152.831111              422.117778
llm-standard-plan                  66.395263    4897.750000     3037.848889  0.911111             921.841111              370.150000
llm-standard-random-plan           71.636608    8099.046667     2573.174444  0.901111            2870.234444              452.200000
pyperplan-only                     50.559363   10996.207778     3406.708889  0.900000            3917.708889              566.367778
```