### PR TITLE
Improve table

### DIFF
--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -212,7 +212,7 @@ def _create_summary_table(raw_results: pd.DataFrame,
             'random-actions': 'random actions',
             'pyperplan-only': 'Pure Planning'
         })
-    
+
     latex = summary_nested.to_latex()
     for col in summary_nested:
         upper_string = col[0]

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -200,6 +200,18 @@ def _create_summary_table(raw_results: pd.DataFrame,
             summary_nested = summary_nested.drop(
                 columns=['success_nodes_created', 'success_nodes_expanded'],
                 level=1)
+    # Adding Averages row
+    avgs = []
+    for col in summary_nested:
+        SUM = 0.0
+        number = 0.0
+        for num in summary_nested[col]:
+            SUM += float(num)
+            number += 1.0
+        avg = round(SUM/number,3)
+        avgs.append(avg)
+    summary_nested.loc['Average'] = avgs
+
     # Changing names
     print(summary_nested)
     summary_nested = summary_nested.rename(
@@ -214,6 +226,12 @@ def _create_summary_table(raw_results: pd.DataFrame,
         })
 
     latex = summary_nested.to_latex()
+
+    # Adding horizontal line for averages
+    intermediate = latex.split('\n')
+    n = len(intermediate)
+    latex = '\n'.join(intermediate[:n-4]+['\\hline']+intermediate[n-4:])
+    
     for col in summary_nested:
         upper_string = col[0]
         if upper_string == 'llm standard':

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -208,7 +208,7 @@ def _create_summary_table(raw_results: pd.DataFrame,
         for num in summary_nested[col]:
             SUM += float(num)
             number += 1.0
-        avg = round(SUM/number,3)
+        avg = round(SUM / number, 3)
         avgs.append(avg)
     summary_nested.loc['Average'] = avgs
 
@@ -230,8 +230,9 @@ def _create_summary_table(raw_results: pd.DataFrame,
     # Adding horizontal line for averages
     intermediate = latex.split('\n')
     n = len(intermediate)
-    latex = '\n'.join(intermediate[:n-4]+['\\hline']+intermediate[n-4:])
-    
+    latex = '\n'.join(intermediate[:n - 4] + ['\\hline'] +
+                      intermediate[n - 4:])
+
     for col in summary_nested:
         upper_string = col[0]
         if upper_string == 'llm standard':

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -172,6 +172,27 @@ def _create_summary_table(raw_results: pd.DataFrame,
         for _, row in summary.iterrows():
             for metric in metrics:
                 reshaped_data[row.env][(row.approach_id, metric)] = row[metric]
+        # Reorder the approaches.
+        approach_order = [
+            'llm-standard',
+            'llm-standard-plan',
+            'llm-standard-random-plan',
+            'llm-standard-no-autoregress',
+            'llm-standard-no-autoregress-plan',
+            'random-names-no-autoregress',
+            'random-actions',
+            'pyperplan-only',
+            'fd-only',
+        ]
+        for env, env_data in reshaped_data.items():
+
+            def _sort_key(key):
+                approach, metric = key
+                return (approach_order.index(approach), metrics.index(metric))
+
+            sorted_keys = sorted(env_data.keys(), key=_sort_key)
+            reshaped_data[env] = {k: env_data[k] for k in sorted_keys}
+
         summary_nested = pd.DataFrame(reshaped_data).transpose()
         # Report the total number of results.
         print(f"\nTOTAL RESULTS: {df.shape[0]}")
@@ -218,6 +239,7 @@ def _create_summary_table(raw_results: pd.DataFrame,
             'llm-standard-random-plan': 'LLM Standard Random Plan',
             'llm-standard-no-autoregress': 'No Autoregress',
             'llm-standard-no-autoregress-plan': 'No Autoregress Plan',
+            'random-names-no-autoregress': 'Ablate Names',
             'random-actions': 'Random',
             'pyperplan-only': 'Pure Planning',
             'fd-only': 'Fast Downward'
@@ -296,7 +318,7 @@ def _latex_formatting(latex: str) -> str:
         latex = '\n'.join(intermediate)
     else:
         # Removing success line from open loop and adding c
-        intermediate[0] = """\\begin{tabular}{cccc}"""
+        intermediate[0] = """\\begin{tabular}{ccccc}"""
         latex = '\n'.join(intermediate[0:3] + intermediate[4:])
 
     # Bolding averages


### PR DESCRIPTION
This code will exclusively make the main tables for the paper depending on the script you run:
1. If you run `python scripts/analyze_results.py --results_dir <path to unzipped directory>/all_planning/`, It will make a table with `Pure Planning`, `Random Action Planning`, and `LLM Standard Planning`, each with nodes created, nodes expanded, and success.
2. If you run `python scripts/analyze_results.py --results_dir <path to unzipped directory>/all_open_loop/`, It will make a table with `LLM Standard`, `LLM Standard no Autoregress`, and`Random Actions`(we might want to drop `LLM Standard no Autoregress` from this table to be consistent with 1.), With each only getting their statistics for success. 
I have attached what the tables look like right now for reference.
<img width="437" alt="Screen Shot 2022-09-25 at 4 49 56 PM" src="https://user-images.githubusercontent.com/70421122/192165103-67e36b9b-af77-4e36-aeb8-8a0ba7649900.png">
